### PR TITLE
chore: bump to 0.2.3

### DIFF
--- a/fuzon-http/Cargo.toml
+++ b/fuzon-http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuzon-http"
-version = "0.1.0"
+version = "0.2.3"
 license.workspace = true
 edition.workspace = true
 

--- a/fuzon/Cargo.toml
+++ b/fuzon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuzon"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 
 [lib]

--- a/pyfuzon/Cargo.toml
+++ b/pyfuzon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyfuzon"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 
 [lib]


### PR DESCRIPTION
bump all crates to 0.2.3 after adjustments made for fuzon-http