### PR TITLE
chore(ci): use only extra substituters

### DIFF
--- a/tools/nix/flake.nix
+++ b/tools/nix/flake.nix
@@ -2,8 +2,7 @@
   description = "fuzon";
 
   nixConfig = {
-    extra-trusted-substituters = [
-      "https://cache.nixos.org/"
+    extra-substituters = [
       # Nix community's cache server
       "https://nix-community.cachix.org"
     ];


### PR DESCRIPTION
- Only add extra-substituters for enabling CI caching. Otherwise CI cannot add a extra substituter in `/etc/nix/nix.conf` (before eval. this flake) since the substituters are hard coded in here.

From: https://gitlab.com/data-custodian/custodian/-/merge_requests/488