### PR TITLE
feat: serde + caching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -891,6 +891,7 @@ dependencies = [
  "reqwest",
  "rff",
  "serde",
+ "tempfile",
 ]
 
 [[package]]
@@ -2300,9 +2301,9 @@ checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
 name = "tempfile"
-version = "3.12.0"
+version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04cbcdd0c794ebb0d4cf35e88edd2f7d2c4c3e9a5a6dab322839b321c6a87a64"
+checksum = "f0f2c9fc62d0beef6951ccffd757e241266a2c833136efbe35af6cd2567dca5b"
 dependencies = [
  "cfg-if",
  "fastrand",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -308,6 +308,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86fdf8605db99b54d3cd748a44c6d04df638eb5dafb219b135d0149bd0db01f6"
 
 [[package]]
+name = "atomic-polyfill"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cf2bce30dfe09ef0bfaef228b9d414faaf7e563035494d7fe092dba54b300f4"
+dependencies = [
+ "critical-section",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -342,7 +351,7 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -508,6 +517,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
 
 [[package]]
+name = "cobs"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67ba02a97a2bd10f4b59b25c7973101c79642302776489e030cd13cdab09ed15"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -577,6 +592,12 @@ checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "critical-section"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f64009896348fc5af4222e9cf7d7d82a95a256c634ebcf61c53e4ea461422242"
 
 [[package]]
 name = "crossbeam-deque"
@@ -671,10 +692,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "either"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+
+[[package]]
+name = "embedded-io"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
+
+[[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
 name = "encoding_rs"
@@ -822,23 +876,26 @@ dependencies = [
 
 [[package]]
 name = "fuzon"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "clap 4.5.18",
  "crossterm",
+ "dirs",
  "lazy_static",
  "oxrdf 0.1.7",
  "oxrdfio",
  "oxttl",
+ "postcard",
  "ratatui",
  "reqwest",
  "rff",
+ "serde",
 ]
 
 [[package]]
 name = "fuzon-http"
-version = "0.1.0"
+version = "0.2.3"
 dependencies = [
  "actix-web",
  "clap 4.5.18",
@@ -915,6 +972,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hash32"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -922,6 +988,20 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
  "ahash",
  "allocator-api2",
+]
+
+[[package]]
+name = "heapless"
+version = "0.7.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdc6457c0eb62c71aac4bc17216026d8410337c4126773b9c5daba343f17964f"
+dependencies = [
+ "atomic-polyfill",
+ "hash32",
+ "rustc_version",
+ "serde",
+ "spin",
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -1187,6 +1267,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
 
 [[package]]
+name = "libredox"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
+dependencies = [
+ "bitflags 2.6.0",
+ "libc",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1370,6 +1460,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
 name = "oxilangtag"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1465,7 +1561,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1525,6 +1621,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da544ee218f0d287a911e9c99a39a8c9bc8fcad3cb8db5959940044ecfc67265"
 
 [[package]]
+name = "postcard"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f7f0a8d620d71c457dd1d47df76bb18960378da56af4527aaa10f515eee732e"
+dependencies = [
+ "cobs",
+ "embedded-io 0.4.0",
+ "embedded-io 0.6.1",
+ "heapless",
+ "serde",
+]
+
+[[package]]
 name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1550,7 +1659,7 @@ dependencies = [
 
 [[package]]
 name = "pyfuzon"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "clap 4.5.18",
@@ -1723,6 +1832,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0884ad60e090bf1345b93da0a5de8923c93884cd03f40dfcfddd3b4bee661853"
 dependencies = [
  "bitflags 2.6.0",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom",
+ "libredox",
+ "thiserror",
 ]
 
 [[package]]
@@ -2075,6 +2195,15 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "static_assertions"
@@ -2580,7 +2709,7 @@ checksum = "e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0"
 dependencies = [
  "windows-result",
  "windows-strings",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2589,7 +2718,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2599,7 +2728,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
 dependencies = [
  "windows-result",
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -2608,7 +2746,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2617,7 +2755,22 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -2626,15 +2779,21 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
  "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -2644,9 +2803,21 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2662,9 +2833,21 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2674,9 +2857,21 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/data/test_schema.ttl
+++ b/data/test_schema.ttl
@@ -3,6 +3,7 @@
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix schema: <http://schema.org/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix : <http://example.org/> .
 
 :Repo a rdfs:Class ;
     rdfs:subClassOf schema:SoftwareSourceCode ;

--- a/data/test_schema.ttl
+++ b/data/test_schema.ttl
@@ -1,0 +1,66 @@
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix schema: <http://schema.org/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+:Repo a rdfs:Class ;
+    rdfs:subClassOf schema:SoftwareSourceCode ;
+    rdfs:label "Repository" ;
+    rdfs:comment """A repository (of code, of data, of documentation, etc.).""" .
+
+schema:ScholarlyArticle a rdfs:Class ;
+    rdfs:label "ScholarlyArticle" ;
+    rdfs:comment "A scholarly article." ;
+    rdfs:subClassOf schema:Article .
+
+schema:Organization a rdfs:Class ;
+    rdfs:label "Organization" ;
+    rdfs:comment "An organization such as a school, NGO, corporation, club, etc." .
+
+schema:Person a rdfs:Class ;
+    rdfs:label "Person" ;
+    rdfs:comment "A person (alive, dead, undead, or fictional)." .
+
+### Properties
+
+schema:abstract a rdf:Property ;
+    rdfs:label "abstract" ;
+    rdfs:comment "An abstract is a short description that summarizes a [[CreativeWork]]." ;
+    rdfs:domain schema:ScholarlyArticle ;
+    rdfs:range xsd:string .
+
+schema:keywords a rdf:Property ;
+    rdfs:label "keywords" ;
+    rdfs:comment "Keywords or tags used to describe some item. Multiple textual entries in a keywords list are typically delimited by commas, or by repeating the property." ;
+    rdfs:domain schema:ScholarlyArticle, :Repo ;
+    rdfs:range xsd:string .
+
+schema:description a rdf:Property ;
+    rdfs:label "description" ;
+    rdfs:comment "A description of the item." ;
+    rdfs:domain :Repo ;
+    rdfs:range xsd:string .
+
+schema:programmingLanguage a rdf:Property ;
+    rdfs:label "programming language" ;
+    rdfs:domain :Repo ;
+    rdfs:range xsd:string .
+
+schema:name a rdf:Property ;
+    rdfs:label "name" ;
+    rdfs:comment "The name of the item." ;
+    rdfs:domain :Repo, schema:Person, schema:Organization, schema:ScholarlyArticle ;
+    rdfs:range xsd:string .
+
+schema:author a rdf:Property;
+    rdfs:label "author" ;
+    rdfs:comment "The author of this content or rating." ;
+    rdfs:domain :Repo, schema:ScholarlyArticle ;
+    rdfs:range schema:Person .
+
+schema:affiliation a rdf:Property ;
+    rdfs:label "affiliation" ;
+    rdfs:comment "An organization that this person is affiliated with. For example, a school/university, a club, or a team." ;
+    rdfs:domain schema:Person ;
+    rdfs:range schema:Organization .

--- a/fuzon/Cargo.toml
+++ b/fuzon/Cargo.toml
@@ -20,3 +20,4 @@ ratatui = "0.28.1"
 reqwest = { version = "0.12.0", features = ["blocking", "native-tls-vendored"] }
 rff = "0.3.0"
 serde = { version = "1.0.210", features = ["derive"] }
+tempfile = "3.13.0"

--- a/fuzon/Cargo.toml
+++ b/fuzon/Cargo.toml
@@ -10,10 +10,13 @@ name = "fuzon"
 anyhow = "1.0.86"
 clap = { version = "4.5.16", features = ["derive"] }
 crossterm = "0.28.1"
+dirs = "5.0.1"
 lazy_static = "1.5.0"
 oxrdf = "0.1.7"
 oxrdfio = "0.1.0"
 oxttl = "0.1.0-rc.1"
+postcard = { version = "1.0.10", features = ["alloc"] }
 ratatui = "0.28.1"
 reqwest = { version = "0.12.0", features = ["blocking", "native-tls-vendored"] }
 rff = "0.3.0"
+serde = { version = "1.0.210", features = ["derive"] }

--- a/fuzon/src/cache.rs
+++ b/fuzon/src/cache.rs
@@ -1,0 +1,68 @@
+use std::fs;
+use std::hash::{DefaultHasher, Hash, Hasher};
+use std::path::PathBuf;
+
+use anyhow::Result;
+use reqwest::blocking::Client;
+use reqwest::Url;
+
+
+/// Requests headers with redirection to create a stamp for the URL
+/// consisting of the last modified date and/or ETag.
+pub fn get_url_stamp(url: &str) -> Result<String> {
+    let client = Client::new();
+    let response = client.head(url).send().unwrap();
+    let headers = response.headers();
+    let etag = headers
+        .get("ETag")
+        .map_or("", |v| v.to_str().unwrap());
+    let last_modified = headers
+        .get("Last-Modified")
+        .map_or("", |v| v.to_str().unwrap());
+    return Ok(format!("{}-{}-{}", url, etag, last_modified));
+}
+
+/// Crafts a file metadata to create a stamp consisting of the file path,
+/// size and last modified date.
+pub fn get_file_stamp(path: &str) -> Result<String> {
+    let metadata = fs::metadata(path).unwrap();
+    let size = metadata.len();
+    let modified = metadata.modified().unwrap();
+    return Ok(format!("{}-{}-{:?}", path, size, modified));
+}
+
+/// Generate a fixed cache key based on a collection of source paths.
+/// Each path is converted to a stamp in the format "{path}-{fingerprint}-{modified-date}".
+/// Stamps are then concatenated and hash of this concatenation is returned.
+pub fn get_cache_key(sources: &Vec<&str>) -> String {
+    let mut paths = sources.clone();
+    paths.sort();
+    let concat = paths
+        .into_iter()
+        .map(|s|
+            if let Ok(_) = Url::parse(s) {
+                get_url_stamp(&s).unwrap()
+            } else {
+                get_file_stamp(&s).unwrap()
+            }
+        )
+        .collect::<Vec<String>>()
+        .join(" ");
+    let mut state = DefaultHasher::new();
+    concat.hash(&mut state);
+    let key = state.finish();
+
+    return key.to_string()
+}
+
+/// Get the full cross-platform cache path for a collection of source paths.
+pub fn get_cache_path(sources: &Vec<&str>) -> PathBuf {
+
+    let cache_dir = dirs::cache_dir().unwrap().join("fuzon");
+    let cache_key = get_cache_key(
+        &sources
+    );
+
+    return cache_dir.join(&cache_key)
+
+}

--- a/fuzon/src/cache.rs
+++ b/fuzon/src/cache.rs
@@ -79,10 +79,10 @@ mod tests {
     }
 
     #[test]
-    fn url_stamp() {
-        let url = "https://www.rust-lang.org/";
+    fn url_no_headers() {
+        let url = "https://google.com";
         let stamp = get_url_stamp(url).unwrap();
-        assert!(stamp.starts_with(url));
+        assert_eq!(stamp, format!("{}--", url));
     }
 
     #[test]

--- a/fuzon/src/cache.rs
+++ b/fuzon/src/cache.rs
@@ -66,3 +66,30 @@ pub fn get_cache_path(sources: &Vec<&str>) -> PathBuf {
     return cache_dir.join(&cache_key)
 
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn file_stamp() {
+        let path = "Cargo.toml";
+        let stamp = get_file_stamp(path).unwrap();
+        assert!(stamp.starts_with(path));
+    }
+
+    #[test]
+    fn url_stamp() {
+        let url = "https://www.rust-lang.org/";
+        let stamp = get_url_stamp(url).unwrap();
+        assert!(stamp.starts_with(url));
+    }
+
+    #[test]
+    fn cache_path() {
+        let sources = vec!["Cargo.toml", "https://www.rust-lang.org/"];
+        let path = get_cache_path(&sources);
+        let key = get_cache_key(&sources);
+        assert!(path.ends_with(key));
+    }
+}

--- a/fuzon/src/lib.rs
+++ b/fuzon/src/lib.rs
@@ -3,7 +3,7 @@ use std::collections::HashSet;
 use std::fs::File;
 use std::path::{Path, PathBuf};
 use std::hash::{DefaultHasher, Hash, Hasher};
-use std::io::{BufRead, BufReader, Read, Write};
+use std::io::{BufRead, BufReader};
 
 use anyhow::Result;
 use dirs;

--- a/fuzon/src/lib.rs
+++ b/fuzon/src/lib.rs
@@ -1,12 +1,10 @@
 use core::fmt;
 use std::collections::HashSet;
 use std::fs::File;
-use std::path::{Path, PathBuf};
-use std::hash::{DefaultHasher, Hash, Hasher};
+use std::path::Path;
 use std::io::{BufRead, BufReader};
 
 use anyhow::Result;
-use dirs;
 use lazy_static::lazy_static;
 use oxrdfio::{RdfFormat, RdfParser};
 use postcard;
@@ -18,6 +16,7 @@ use rff;
 
 
 pub mod ui;
+pub mod cache;
 
 // HashMap of common annotation properties
 lazy_static! {
@@ -158,26 +157,4 @@ pub fn gather_terms(readers: Vec<(impl BufRead, RdfFormat)>) -> impl Iterator<It
     terms.into_iter()
 }
 
-/// Generate a fixed cache key based on a collection of source paths.
-pub fn get_cache_key(sources: &Vec<&str>) -> String {
-    let mut paths = sources.clone();
-    paths.sort();
-    let concat = paths.join(" ");
-    let mut state = DefaultHasher::new();
-    concat.hash(&mut state);
-    let key = state.finish();
 
-    return key.to_string()
-}
-
-/// Get the full cross-platform cache path for a collection of source paths.
-pub fn get_cache_path(sources: &Vec<&str>) -> PathBuf {
-
-    let cache_dir = dirs::cache_dir().unwrap().join("fuzon");
-    let cache_key = get_cache_key(
-        &sources
-    );
-
-    return cache_dir.join(&cache_key)
-
-}

--- a/fuzon/src/lib.rs
+++ b/fuzon/src/lib.rs
@@ -158,3 +158,14 @@ pub fn gather_terms(readers: Vec<(impl BufRead, RdfFormat)>) -> impl Iterator<It
 }
 
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn matcher_from_source() {
+        let source = vec!["../data/test_schema.ttl"];
+        let matcher = TermMatcher::from_paths(source).unwrap();
+        assert_eq!(matcher.terms.len(), 11);
+    }
+}

--- a/fuzon/src/lib.rs
+++ b/fuzon/src/lib.rs
@@ -168,4 +168,23 @@ mod tests {
         let matcher = TermMatcher::from_paths(source).unwrap();
         assert_eq!(matcher.terms.len(), 11);
     }
+
+    #[test]
+    fn rank_terms() {
+        let source = vec!["../data/test_schema.ttl"];
+        let matcher = TermMatcher::from_paths(source).unwrap();
+        let query = "Person";
+        let ranked = matcher.rank_terms(query);
+        assert_eq!(ranked[0].0.label, "\"Person\"");
+    }
+
+    #[test]
+    fn serde() {
+        let source = vec!["../data/test_schema.ttl"];
+        let matcher = TermMatcher::from_paths(source).unwrap();
+        let path = Path::new("test_cache");
+        let _ = matcher.dump(path);
+        let loaded = TermMatcher::load(path).unwrap();
+        assert_eq!(matcher, loaded);
+    }
 }

--- a/fuzon/src/lib.rs
+++ b/fuzon/src/lib.rs
@@ -161,6 +161,7 @@ pub fn gather_terms(readers: Vec<(impl BufRead, RdfFormat)>) -> impl Iterator<It
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tempfile;
 
     #[test]
     fn matcher_from_source() {
@@ -182,9 +183,9 @@ mod tests {
     fn serde() {
         let source = vec!["../data/test_schema.ttl"];
         let matcher = TermMatcher::from_paths(source).unwrap();
-        let path = Path::new("test_cache");
-        let _ = matcher.dump(path);
-        let loaded = TermMatcher::load(path).unwrap();
+        let out = tempfile::NamedTempFile::new().unwrap();
+        let _ = matcher.dump(&out.path());
+        let loaded = TermMatcher::load(&out.path()).unwrap();
         assert_eq!(matcher, loaded);
     }
 }

--- a/fuzon/src/main.rs
+++ b/fuzon/src/main.rs
@@ -54,13 +54,14 @@ fn main() -> Result<()> {
     } else {
         matcher = TermMatcher::from_paths(sources)?;
     }
-    //matcher.clone().dump(Path::new("./terms.bin"))?;
 
+    // Search for query
     if let Some(query) = args.query {
         for (term, score) in search(&matcher, &query, args.top) {
             println!("[{}] {}", score, term)
         }
         return Ok(());
+    // Or interactively trigger search on keystrokes
     } else {
         return interactive(&matcher, args.top);
     }

--- a/fuzon/src/main.rs
+++ b/fuzon/src/main.rs
@@ -3,7 +3,8 @@ use fuzon::ui::{interactive, search};
 
 use anyhow::Result;
 use clap::Parser;
-use fuzon::{get_cache_path, TermMatcher};
+use fuzon::TermMatcher;
+use fuzon::cache::get_cache_path;
 
 /// fuzzy match terms from ontologies to get their uri
 #[derive(Parser, Debug)]
@@ -41,13 +42,13 @@ fn main() -> Result<()> {
         );
         let _ = fs::create_dir_all(cache_path.parent().unwrap());
         // Cache hit
-        matcher = if let Ok(m) = TermMatcher::load(&cache_path) {
-           m 
+        matcher = if let Ok(matcher) = TermMatcher::load(&cache_path) {
+           matcher
         // Cache miss
         } else {
-            let m =TermMatcher::from_paths(sources)?;
-            m.dump(&cache_path)?;
-            m 
+            let matcher =TermMatcher::from_paths(sources)?;
+            matcher.dump(&cache_path)?;
+            matcher 
         };
     } else {
         matcher = TermMatcher::from_paths(sources)?;

--- a/fuzon/src/main.rs
+++ b/fuzon/src/main.rs
@@ -1,10 +1,8 @@
 use std::fs;
-use std::path::Path;
 use fuzon::ui::{interactive, search};
 
 use anyhow::Result;
 use clap::Parser;
-use dirs;
 use fuzon::{get_cache_path, TermMatcher};
 
 /// fuzzy match terms from ontologies to get their uri

--- a/pyfuzon/python/pyfuzon/matcher.py
+++ b/pyfuzon/python/pyfuzon/matcher.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 from typing import Self
 from dataclasses import dataclass
 
-from pyfuzon import Term, score_terms, parse_files
+from pyfuzon import Term, score_terms, parse_files, load_terms, dump_terms
 
 
 @dataclass
@@ -10,9 +10,11 @@ class TermMatcher:
     terms: list[Term]
     
     def top(self, query: str, n: int=5) -> list[Term]:
+        """Return the n terms most similar to input query."""
         return self.rank(query)[:n]
 
     def rank(self, query: str) -> list[Term]:
+        """Return all terms, ranked by query similarity."""
         scores = self.score(query)
         ranks = [
             i[0] for i in 
@@ -21,10 +23,24 @@ class TermMatcher:
         return [self.terms[rank] for rank in ranks]
 
     def score(self, query: str) -> list[float]:
+        """Return all terms with a similarity score to the query."""
         return score_terms(query, self.terms)
 
     @classmethod
     def from_files(cls, paths: list[str]) -> Self:
+        """Create a TermMatcher from a list of paths to source ontologies.
+        Both filepaths and URLs are supported.
+        """
         terms = parse_files(paths)
         return cls(terms)
+
+    @classmethod
+    def load(cls, path):
+        """Deserialize a TermMatcher object from disk."""
+        terms = load_terms(path)
+        return cls(terms)
+
+    def dump(self, path):
+        """Serialize to disk."""
+        dump_terms(self.terms, path)
 

--- a/pyfuzon/python/pyfuzon/matcher.py
+++ b/pyfuzon/python/pyfuzon/matcher.py
@@ -7,6 +7,8 @@ from pyfuzon import Term, score_terms, parse_files, load_terms, dump_terms
 
 @dataclass
 class TermMatcher:
+    """Fuzzy matches terms from RDF terminologies to input queries."""
+
     terms: list[Term]
     
     def top(self, query: str, n: int=5) -> list[Term]:

--- a/pyfuzon/src/lib.rs
+++ b/pyfuzon/src/lib.rs
@@ -5,6 +5,8 @@ use core::fmt;
 use fuzon::{get_source, gather_terms, TermMatcher};
 use rff;
 
+/// A struct to represent a term from an ontology.
+/// This mirrors fuzon::Term while making it easier to use in Python.
 #[pyclass]
 #[derive(Debug, Clone)]
 pub struct Term {
@@ -37,6 +39,7 @@ impl fmt::Display for Term {
 }
 
 
+/// Returns a vector of similarity scores for each term to the query
 #[pyfunction]
 pub fn score_terms(query: String, terms: Vec<Term>) -> PyResult<Vec<f64>> {
     let scores: Vec<f64> = terms
@@ -51,6 +54,7 @@ pub fn score_terms(query: String, terms: Vec<Term>) -> PyResult<Vec<f64>> {
     return Ok(scores);
 }
 
+/// Parse and filter RDF files to gather the union of all terms.
 #[pyfunction]
 pub fn parse_files(paths: Vec<String>) -> PyResult<Vec<Term>> {
         let readers = paths.iter().map(|p| get_source(p).unwrap()).collect();
@@ -61,6 +65,8 @@ pub fn parse_files(paths: Vec<String>) -> PyResult<Vec<Term>> {
     return Ok(terms)
 }
 
+/// Extract terms from a serialized fuzon TermMatcher.
+/// This is faster than parsing RDF files.
 #[pyfunction]
 pub fn load_terms(path: PathBuf) -> PyResult<Vec<Term>> {
     let terms: Vec<Term> = TermMatcher::load(&path)
@@ -73,6 +79,7 @@ pub fn load_terms(path: PathBuf) -> PyResult<Vec<Term>> {
     return Ok(terms)
 }
 
+/// Serialize the provided terms as a fuzon TermMatcher.
 #[pyfunction]
 pub fn dump_terms(terms: Vec<Term>, path: PathBuf) -> PyResult<()> {
     let mut matcher = TermMatcher::new();

--- a/pyfuzon/src/lib.rs
+++ b/pyfuzon/src/lib.rs
@@ -1,7 +1,8 @@
+use std::{fmt::write, path::PathBuf};
 use pyo3::prelude::*;
 use core::fmt;
 
-use fuzon::{get_source, gather_terms};
+use fuzon::{get_source, gather_terms, TermMatcher};
 use rff;
 
 #[pyclass]
@@ -56,7 +57,32 @@ pub fn parse_files(paths: Vec<String>) -> PyResult<Vec<Term>> {
         let terms = gather_terms(readers)
             .map(|t| Term::new(t.uri, t.label))
             .collect();
-        Ok(terms)
+    
+    return Ok(terms)
+}
+
+#[pyfunction]
+pub fn load_terms(path: PathBuf) -> PyResult<Vec<Term>> {
+    let terms: Vec<Term> = TermMatcher::load(&path)
+        .unwrap()
+        .terms
+        .into_iter()
+        .map(|t| Term::new(t.uri, t.label))
+        .collect();
+
+    return Ok(terms)
+}
+
+#[pyfunction]
+pub fn dump_terms(terms: Vec<Term>, path: PathBuf) -> PyResult<()> {
+    let mut matcher = TermMatcher::new();
+    matcher.terms = terms
+        .into_iter()
+        .map(|t| fuzon::Term{ uri: t.uri, label: t.label })
+        .collect();
+    matcher.dump(&path).unwrap();
+
+    return Ok(())
 }
 
 
@@ -64,6 +90,8 @@ pub fn parse_files(paths: Vec<String>) -> PyResult<Vec<Term>> {
 fn pyfuzon(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(score_terms, m)?)?;
     m.add_function(wrap_pyfunction!(parse_files, m)?)?;
+    m.add_function(wrap_pyfunction!(load_terms, m)?)?;
+    m.add_function(wrap_pyfunction!(dump_terms, m)?)?;
     m.add_class::<Term>()?;
     Ok(())
 }

--- a/pyfuzon/src/lib.rs
+++ b/pyfuzon/src/lib.rs
@@ -1,4 +1,4 @@
-use std::{fmt::write, path::PathBuf};
+use std::path::PathBuf;
 use pyo3::prelude::*;
 use core::fmt;
 


### PR DESCRIPTION
## Context

Loading and filtering the ontology when instantiating a `TermMatcher` object
 is by far the slowest operation in (py)fuzon.

## Summary

This PR adds efficient (de)serialization support to fuzon::TermMatcher using [postcard](https://docs.rs/postcard/latest/postcard/), a low overhead binary serializer.

## Changes

* Implement SerDe on TermMatcher
* Implement caching in CLI to prevent re-downloading the same ontologies over and over again.
  + cache keys are built from the path, last-modified timestamp and ETag(url) / size(file) of ontologies
  + if there are multiple ontologies, their data are sorted+concatenated before hashing
* Implement pyo3 bindings to TermMatcher::load/dump in pyfuzon
* Expose load/dump functionality in python API

## Notes

Basic tests with the uberon ontology showed the following:

* The full ontology is 89MB
* Once filtered (by the TermMatcher constructor), we are down to ~2MB
* Creating a TermMatcher from scratch with locally stored UBERON took 2.765 (on NVMe).
* WIth postcard, deserializing a TermMatcher takes 65ms, the object dump takes 2.1MB

## Current limitations

* There is currently no way to cleanup the cache (besides deleting the cache directory). Would it make sense to add it as a CLI flag?