### PR TITLE
feat(py): caching support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1494,9 +1494,9 @@ dependencies = [
 
 [[package]]
 name = "oxrdf"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c23ac4556485d4d4c31f3448a7ccc53d2444617a5e46ccc39f2f5a74e28091e"
+checksum = "6b2115dc40840037ba86c494ffa2925ab435ec0c383dcf73d49600c9142db081"
 dependencies = [
  "oxilangtag",
  "oxiri",
@@ -1506,11 +1506,11 @@ dependencies = [
 
 [[package]]
 name = "oxrdfio"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4706c6af55788842d2db36cff725001f4d3b84882bcccb6c19d798542742cf6"
+checksum = "62b05ae7eeab84240bdf87bc8db8da4622a0ad202375e4de50ce32e97ea4061b"
 dependencies = [
- "oxrdf 0.2.0",
+ "oxrdf 0.2.1",
  "oxrdfxml",
  "oxttl",
  "thiserror",
@@ -1518,27 +1518,27 @@ dependencies = [
 
 [[package]]
 name = "oxrdfxml"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb88436b3c4375d87d320387f9b6fa84a772ea927ad0a9458fc35780605cda47"
+checksum = "7f7b10f0ba68e0a300346264a97c33ad26d1e16700d481c4809caef26195a04a"
 dependencies = [
  "oxilangtag",
  "oxiri",
- "oxrdf 0.2.0",
+ "oxrdf 0.2.1",
  "quick-xml",
  "thiserror",
 ]
 
 [[package]]
 name = "oxttl"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9795d5819708ef1669906eb96783a1764bf4b283f7615d46f66a798e8101fd3b"
+checksum = "b5ff45d05226b72a41cb43bb5818149be337231c2db7c3501f0f3b1e29977748"
 dependencies = [
  "memchr",
  "oxilangtag",
  "oxiri",
- "oxrdf 0.2.0",
+ "oxrdf 0.2.1",
  "thiserror",
 ]
 
@@ -1680,6 +1680,7 @@ version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15ee168e30649f7f234c3d49ef5a7a6cbf5134289bc46c29ff3155fa3221c225"
 dependencies = [
+ "anyhow",
  "cfg-if",
  "indoc",
  "libc",

--- a/fuzon/src/cache.rs
+++ b/fuzon/src/cache.rs
@@ -37,8 +37,8 @@ pub fn get_file_stamp(path: &str) -> Result<String> {
 pub fn get_cache_key(paths: &mut Vec<&str>) -> Result<String> {
     paths.sort();
 
-    // Craft all stamps and concatenate them
-    let mut concat = String::new();
+    // Craft all stamps and concatenate them into the hasher
+    let mut state = DefaultHasher::new();
     for path in paths.iter() {
         let stamp = if let Ok(_) = Url::parse(path) {
             get_url_stamp(&path)?
@@ -47,12 +47,10 @@ pub fn get_cache_key(paths: &mut Vec<&str>) -> Result<String> {
         } else {
             return Err(anyhow::anyhow!("Invalid path: {}", path));
         };
-        concat.push_str(&stamp);
+        stamp.hash(&mut state);
     }
 
     // Hash the concatenated stamps
-    let mut state = DefaultHasher::new();
-    concat.hash(&mut state);
     let key = state.finish();
 
     return Ok(key.to_string());

--- a/fuzon/src/cache.rs
+++ b/fuzon/src/cache.rs
@@ -34,12 +34,12 @@ pub fn get_file_stamp(path: &str) -> Result<String> {
 /// Generate a fixed cache key based on a collection of source paths.
 /// Each path is converted to a stamp in the format "{path}-{fingerprint}-{modified-date}".
 /// Stamps are then concatenated and hash of this concatenation is returned.
-pub fn get_cache_key(paths: Vec<&str>) -> Result<String> {
+pub fn get_cache_key(paths: &mut Vec<&str>) -> Result<String> {
     paths.sort();
 
     // Craft all stamps and concatenate them
     let mut concat = String::new();
-    for path in paths.into_iter() {
+    for path in paths.iter() {
         if !PathBuf::from(path).exists() && Url::parse(path).is_err() {
             return Err(anyhow::anyhow!("Invalid path: {}", path));
         }
@@ -61,9 +61,9 @@ pub fn get_cache_key(paths: Vec<&str>) -> Result<String> {
 }
 
 /// Get the full cross-platform cache path for a collection of source paths.
-pub fn get_cache_path(sources: &Vec<&str>) -> Result<PathBuf> {
+pub fn get_cache_path(sources: &mut Vec<&str>) -> Result<PathBuf> {
     let cache_dir = dirs::cache_dir().unwrap().join("fuzon");
-    let cache_key = get_cache_key(&sources)?;
+    let cache_key = get_cache_key(sources)?;
     let cache_path = cache_dir.join(&cache_key);
 
     return Ok(cache_path);
@@ -89,9 +89,9 @@ mod tests {
 
     #[test]
     fn cache_path() {
-        let sources = vec!["Cargo.toml", "https://www.rust-lang.org/"];
-        let path = get_cache_path(&sources).unwrap();
-        let key = get_cache_key(&sources).unwrap();
+        let mut sources = vec!["Cargo.toml", "https://www.rust-lang.org/"];
+        let path = get_cache_path(&mut sources.clone()).unwrap();
+        let key = get_cache_key(&mut sources).unwrap();
         assert!(path.ends_with(key));
     }
 }

--- a/fuzon/src/cache.rs
+++ b/fuzon/src/cache.rs
@@ -69,12 +69,9 @@ pub fn get_cache_path(sources: &mut Vec<&str>) -> Result<PathBuf> {
 
 /// Save each source into an independent TermMatcher cache file.
 pub fn cache_by_source(sources: Vec<&str>) -> Result<()> {
-    let mut matcher: TermMatcher;
-    let mut cache_path: PathBuf;
-
     for source in sources {
-        matcher = TermMatcher::from_paths(vec![source])?;
-        cache_path = get_cache_path(&mut vec![source])?;
+        let matcher = TermMatcher::from_paths(vec![source])?;
+        let cache_path = get_cache_path(&mut vec![source])?;
         matcher.dump(&cache_path)?;
     }
 

--- a/fuzon/src/cache.rs
+++ b/fuzon/src/cache.rs
@@ -1,70 +1,73 @@
-use std::fs;
-use std::hash::{DefaultHasher, Hash, Hasher};
-use std::path::PathBuf;
+use std::{
+    fs,
+    hash::{DefaultHasher, Hash, Hasher},
+    path::PathBuf,
+};
 
 use anyhow::Result;
-use reqwest::blocking::Client;
-use reqwest::Url;
-
+use reqwest::{blocking::Client, Url};
 
 /// Requests headers with redirection to create a stamp for the URL
 /// consisting of the last modified date and/or ETag.
 pub fn get_url_stamp(url: &str) -> Result<String> {
     let client = Client::new();
-    let response = client.head(url).send().unwrap();
+    let response = client.head(url).send()?;
     let headers = response.headers();
-    let etag = headers
-        .get("ETag")
-        .map_or("", |v| v.to_str().unwrap());
+    let etag = headers.get("ETag").map_or("", |v| v.to_str().unwrap());
     let last_modified = headers
         .get("Last-Modified")
         .map_or("", |v| v.to_str().unwrap());
+
     return Ok(format!("{}-{}-{}", url, etag, last_modified));
 }
 
 /// Crafts a file metadata to create a stamp consisting of the file path,
 /// size and last modified date.
 pub fn get_file_stamp(path: &str) -> Result<String> {
-    let metadata = fs::metadata(path).unwrap();
+    let metadata = fs::metadata(path)?;
     let size = metadata.len();
-    let modified = metadata.modified().unwrap();
+    let modified = metadata.modified()?;
+
     return Ok(format!("{}-{}-{:?}", path, size, modified));
 }
 
 /// Generate a fixed cache key based on a collection of source paths.
 /// Each path is converted to a stamp in the format "{path}-{fingerprint}-{modified-date}".
 /// Stamps are then concatenated and hash of this concatenation is returned.
-pub fn get_cache_key(sources: &Vec<&str>) -> String {
+pub fn get_cache_key(sources: &Vec<&str>) -> Result<String> {
     let mut paths = sources.clone();
     paths.sort();
-    let concat = paths
-        .into_iter()
-        .map(|s|
-            if let Ok(_) = Url::parse(s) {
-                get_url_stamp(&s).unwrap()
-            } else {
-                get_file_stamp(&s).unwrap()
-            }
-        )
-        .collect::<Vec<String>>()
-        .join(" ");
+
+    // Craft all stamps and concatenate them
+    let mut concat = String::new();
+    for path in paths.into_iter() {
+        if !PathBuf::from(path).exists() && Url::parse(path).is_err() {
+            return Err(anyhow::anyhow!("Invalid path: {}", path));
+        }
+
+        let stamp = if let Ok(_) = Url::parse(path) {
+            get_url_stamp(&path)?
+        } else {
+            get_file_stamp(&path)?
+        };
+        concat.push_str(&stamp);
+    }
+
+    // Hash the concatenated stamps
     let mut state = DefaultHasher::new();
     concat.hash(&mut state);
     let key = state.finish();
 
-    return key.to_string()
+    return Ok(key.to_string());
 }
 
 /// Get the full cross-platform cache path for a collection of source paths.
-pub fn get_cache_path(sources: &Vec<&str>) -> PathBuf {
-
+pub fn get_cache_path(sources: &Vec<&str>) -> Result<PathBuf> {
     let cache_dir = dirs::cache_dir().unwrap().join("fuzon");
-    let cache_key = get_cache_key(
-        &sources
-    );
+    let cache_key = get_cache_key(&sources);
+    let cache_path = cache_dir.join(&cache_key?);
 
-    return cache_dir.join(&cache_key)
-
+    return Ok(cache_path);
 }
 
 #[cfg(test)]
@@ -88,8 +91,8 @@ mod tests {
     #[test]
     fn cache_path() {
         let sources = vec!["Cargo.toml", "https://www.rust-lang.org/"];
-        let path = get_cache_path(&sources);
-        let key = get_cache_key(&sources);
+        let path = get_cache_path(&sources).unwrap();
+        let key = get_cache_key(&sources).unwrap();
         assert!(path.ends_with(key));
     }
 }

--- a/fuzon/src/cache.rs
+++ b/fuzon/src/cache.rs
@@ -34,8 +34,7 @@ pub fn get_file_stamp(path: &str) -> Result<String> {
 /// Generate a fixed cache key based on a collection of source paths.
 /// Each path is converted to a stamp in the format "{path}-{fingerprint}-{modified-date}".
 /// Stamps are then concatenated and hash of this concatenation is returned.
-pub fn get_cache_key(sources: &Vec<&str>) -> Result<String> {
-    let mut paths = sources.clone();
+pub fn get_cache_key(paths: Vec<&str>) -> Result<String> {
     paths.sort();
 
     // Craft all stamps and concatenate them

--- a/fuzon/src/cache.rs
+++ b/fuzon/src/cache.rs
@@ -18,7 +18,7 @@ pub fn get_url_stamp(url: &str) -> Result<String> {
         .get("Last-Modified")
         .map_or("", |v| v.to_str().unwrap());
 
-    return Ok(format!("{}-{}-{}", url, etag, last_modified));
+    Ok(format!("{}-{}-{}", url, etag, last_modified))
 }
 
 /// Crafts a file metadata to create a stamp consisting of the file path,
@@ -28,7 +28,7 @@ pub fn get_file_stamp(path: &str) -> Result<String> {
     let size = metadata.len();
     let modified = metadata.modified()?;
 
-    return Ok(format!("{}-{}-{:?}", path, size, modified));
+    Ok(format!("{}-{}-{:?}", path, size, modified))
 }
 
 /// Generate a fixed cache key based on a collection of source paths.
@@ -53,7 +53,7 @@ pub fn get_cache_key(paths: &mut Vec<&str>) -> Result<String> {
     // Hash the concatenated stamps
     let key = state.finish();
 
-    return Ok(key.to_string());
+    Ok(key.to_string())
 }
 
 /// Get the full cross-platform cache path for a collection of source paths.
@@ -62,7 +62,7 @@ pub fn get_cache_path(sources: &mut Vec<&str>) -> Result<PathBuf> {
     let cache_key = get_cache_key(sources)?;
     let cache_path = cache_dir.join(&cache_key);
 
-    return Ok(cache_path);
+    Ok(cache_path)
 }
 
 #[cfg(test)]

--- a/fuzon/src/cache.rs
+++ b/fuzon/src/cache.rs
@@ -64,8 +64,8 @@ pub fn get_cache_key(sources: &Vec<&str>) -> Result<String> {
 /// Get the full cross-platform cache path for a collection of source paths.
 pub fn get_cache_path(sources: &Vec<&str>) -> Result<PathBuf> {
     let cache_dir = dirs::cache_dir().unwrap().join("fuzon");
-    let cache_key = get_cache_key(&sources);
-    let cache_path = cache_dir.join(&cache_key?);
+    let cache_key = get_cache_key(&sources)?;
+    let cache_path = cache_dir.join(&cache_key);
 
     return Ok(cache_path);
 }

--- a/fuzon/src/cache.rs
+++ b/fuzon/src/cache.rs
@@ -40,14 +40,12 @@ pub fn get_cache_key(paths: &mut Vec<&str>) -> Result<String> {
     // Craft all stamps and concatenate them
     let mut concat = String::new();
     for path in paths.iter() {
-        if !PathBuf::from(path).exists() && Url::parse(path).is_err() {
-            return Err(anyhow::anyhow!("Invalid path: {}", path));
-        }
-
         let stamp = if let Ok(_) = Url::parse(path) {
             get_url_stamp(&path)?
-        } else {
+        } else if PathBuf::from(path).exists() {
             get_file_stamp(&path)?
+        } else {
+            return Err(anyhow::anyhow!("Invalid path: {}", path));
         };
         concat.push_str(&stamp);
     }

--- a/fuzon/src/lib.rs
+++ b/fuzon/src/lib.rs
@@ -1,22 +1,22 @@
 use core::fmt;
-use std::collections::HashSet;
-use std::fs::File;
-use std::path::Path;
-use std::io::{BufRead, BufReader};
+use std::{
+    collections::HashSet,
+    fs::File,
+    io::{BufRead, BufReader},
+    path::Path,
+};
 
 use anyhow::Result;
 use lazy_static::lazy_static;
 use oxrdfio::{RdfFormat, RdfParser};
 use postcard;
-use reqwest::blocking::Client;
-use reqwest::Url;
+use reqwest::{blocking::Client, Url};
 use serde::{Deserialize, Serialize};
 
 use rff;
 
-
-pub mod ui;
 pub mod cache;
+pub mod ui;
 
 // HashMap of common annotation properties
 lazy_static! {
@@ -61,18 +61,21 @@ impl TermMatcher {
     }
     pub fn from_readers(readers: Vec<(impl BufRead, RdfFormat)>) -> Self {
         let terms = gather_terms(readers).collect();
+
         TermMatcher { terms }
     }
 
     pub fn from_paths(paths: Vec<&str>) -> Result<Self> {
         let readers = paths.into_iter().map(|p| get_source(p).unwrap()).collect();
         let terms: Vec<Term> = gather_terms(readers).collect();
+
         Ok(TermMatcher { terms })
     }
 
     pub fn load(path: &Path) -> Result<Self> {
         let bytes = std::fs::read(path)?;
         let matcher = postcard::from_bytes(&bytes)?;
+
         Ok(matcher)
     }
 
@@ -82,7 +85,6 @@ impl TermMatcher {
         Ok(())
     }
 }
-
 
 #[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
 pub struct Term {
@@ -134,9 +136,8 @@ pub fn rank_terms<'a>(query: &str, terms: Vec<&'a Term>) -> Vec<(&'a Term, f64)>
         .collect();
     ranked.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap());
 
-    return ranked;
+    ranked
 }
-
 
 // Load URI-label pairs from all sources.
 pub fn gather_terms(readers: Vec<(impl BufRead, RdfFormat)>) -> impl Iterator<Item = Term> {
@@ -154,9 +155,9 @@ pub fn gather_terms(readers: Vec<(impl BufRead, RdfFormat)>) -> impl Iterator<It
             .collect();
         terms.append(&mut out);
     }
+
     terms.into_iter()
 }
-
 
 #[cfg(test)]
 mod tests {

--- a/fuzon/src/lib.rs
+++ b/fuzon/src/lib.rs
@@ -2,7 +2,9 @@ use core::fmt;
 use std::{
     collections::HashSet,
     fs::File,
+    hash::Hash,
     io::{BufRead, BufReader},
+    ops::Add,
     path::Path,
 };
 
@@ -40,6 +42,23 @@ lazy_static! {
 #[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
 pub struct TermMatcher {
     pub terms: Vec<Term>,
+}
+
+impl Add for TermMatcher {
+    type Output = Self;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        // union of terms
+        let terms = self
+            .terms
+            .into_iter()
+            .chain(rhs.terms.into_iter())
+            .collect::<HashSet<Term>>()
+            .into_iter()
+            .collect();
+
+        TermMatcher { terms }
+    }
 }
 
 impl TermMatcher {
@@ -86,7 +105,7 @@ impl TermMatcher {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, Eq, Hash, PartialEq)]
 pub struct Term {
     pub uri: String,
     pub label: String,

--- a/fuzon/src/main.rs
+++ b/fuzon/src/main.rs
@@ -1,10 +1,9 @@
-use std::fs;
 use fuzon::ui::{interactive, search};
+use std::fs;
 
 use anyhow::Result;
 use clap::Parser;
-use fuzon::TermMatcher;
-use fuzon::cache::get_cache_path;
+use fuzon::{cache::get_cache_path, TermMatcher};
 
 /// fuzzy match terms from ontologies to get their uri
 #[derive(Parser, Debug)]
@@ -29,26 +28,21 @@ struct Args {
 fn main() -> Result<()> {
     let args = Args::parse();
 
-    let sources = args.source
-        .iter()
-        .map(|s| s.as_str())
-        .collect();
+    let sources = args.source.iter().map(|s| s.as_str()).collect();
 
     // Attempt to load from cache
     let matcher: TermMatcher;
     if !args.no_cache {
-        let cache_path = get_cache_path(
-            &sources
-        );
+        let cache_path = get_cache_path(&sources)?;
         let _ = fs::create_dir_all(cache_path.parent().unwrap());
         // Cache hit
         matcher = if let Ok(matcher) = TermMatcher::load(&cache_path) {
-           matcher
+            matcher
         // Cache miss
         } else {
-            let matcher =TermMatcher::from_paths(sources)?;
+            let matcher = TermMatcher::from_paths(sources)?;
             matcher.dump(&cache_path)?;
-            matcher 
+            matcher
         };
     } else {
         matcher = TermMatcher::from_paths(sources)?;
@@ -65,8 +59,6 @@ fn main() -> Result<()> {
         return interactive(&matcher, args.top);
     }
 }
-
-
 
 #[cfg(test)]
 mod tests {

--- a/fuzon/src/main.rs
+++ b/fuzon/src/main.rs
@@ -28,12 +28,12 @@ struct Args {
 fn main() -> Result<()> {
     let args = Args::parse();
 
-    let sources = args.source.iter().map(|s| s.as_str()).collect();
+    let mut sources = args.source.iter().map(|s| s.as_str()).collect();
 
     // Attempt to load from cache
     let matcher: TermMatcher;
     if !args.no_cache {
-        let cache_path = get_cache_path(&sources)?;
+        let cache_path = get_cache_path(&mut sources)?;
         let _ = fs::create_dir_all(cache_path.parent().unwrap());
         // Cache hit
         matcher = if let Ok(matcher) = TermMatcher::load(&cache_path) {
@@ -61,8 +61,4 @@ fn main() -> Result<()> {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn match_urls() {}
-}
+mod tests {}

--- a/fuzon/src/main.rs
+++ b/fuzon/src/main.rs
@@ -53,10 +53,10 @@ fn main() -> Result<()> {
         for (term, score) in search(&matcher, &query, args.top) {
             println!("[{}] {}", score, term)
         }
-        return Ok(());
+        Ok(())
     // Or interactively trigger search on keystrokes
     } else {
-        return interactive(&matcher, args.top);
+        interactive(&matcher, args.top)
     }
 }
 

--- a/fuzon/src/ui.rs
+++ b/fuzon/src/ui.rs
@@ -9,17 +9,15 @@ use crossterm::{
 };
 use ratatui::{
     backend::CrosstermBackend,
-    Frame,
     layout::{Constraint, Direction, Layout},
     style::{Color, Style},
-    Terminal,
     widgets::{Block, Borders, List, ListItem, Paragraph},
+    Frame, Terminal,
 };
 
 // Main interaction loop listening to keys, running the search and rendering the UI on each key
 // stroke.
 pub fn interactive(matcher: &TermMatcher, top_n: Option<usize>) -> Result<()> {
-
     // Raw mode does not react to SIGINT, hence we capture it below
     enable_raw_mode()?;
     let mut stdout = stdout();
@@ -38,9 +36,13 @@ pub fn interactive(matcher: &TermMatcher, top_n: Option<usize>) -> Result<()> {
         if let Event::Key(key) = event::read()? {
             match key.code {
                 // Exit on Ctrl-C
-                KeyCode::Char(c) if key.modifiers.contains(KeyModifiers::CONTROL) && c == 'c' => break,
+                KeyCode::Char(c) if key.modifiers.contains(KeyModifiers::CONTROL) && c == 'c' => {
+                    break
+                }
                 KeyCode::Char(c) => query.push(c),
-                KeyCode::Backspace => { query.pop(); },
+                KeyCode::Backspace => {
+                    query.pop();
+                }
                 KeyCode::Esc => break,
                 _ => {}
             }
@@ -50,14 +52,12 @@ pub fn interactive(matcher: &TermMatcher, top_n: Option<usize>) -> Result<()> {
     disable_raw_mode()?;
     execute!(terminal.backend_mut(), LeaveAlternateScreen)?;
     terminal.show_cursor()?;
+
     Ok(())
 }
 
-
 // Draws the TUI elements
-pub fn draw_ui(
-    f: &mut Frame, query: &str, matcher: &TermMatcher, top_n: Option<usize>
-) {
+pub fn draw_ui(f: &mut Frame, query: &str, matcher: &TermMatcher, top_n: Option<usize>) {
     // Split the frame into vertical sections
     let chunks = Layout::default()
         .direction(Direction::Vertical)
@@ -65,33 +65,38 @@ pub fn draw_ui(
         .split(f.area());
 
     // Input block (displays what the user it typing)
-    let input = Paragraph::new(query)
-        .block(Block::default().borders(Borders::ALL).title("Query"));
+    let input = Paragraph::new(query).block(Block::default().borders(Borders::ALL).title("Query"));
 
     // Only show hits
     let results = search(matcher, query, top_n)
         .into_iter()
-        .filter(|(_, score)| *score > 0.0).collect::<Vec<(&Term, f64)>>();
+        .filter(|(_, score)| *score > 0.0)
+        .collect::<Vec<(&Term, f64)>>();
 
     // Results block, shows search results
-    let items: Vec<ListItem> = results.iter().map(|(term, score)| {
-        ListItem::new(format!("[{}] {}", score, term))
-    }).collect();
+    let items: Vec<ListItem> = results
+        .iter()
+        .map(|(term, score)| ListItem::new(format!("[{}] {}", score, term)))
+        .collect();
     let list = List::new(items)
         .block(Block::default().borders(Borders::ALL).title("Results"))
         .style(Style::default().fg(Color::White));
-        
+
     f.render_widget(input, chunks[0]);
     f.render_widget(list, chunks[1]);
-
 }
 
 // Helper to run the fuzzy search and filter top hits if requested.
-pub fn search<'a>(matcher: &'a TermMatcher, query: &str, top_n: Option<usize>) -> Vec<(&'a Term, f64)> {
+pub fn search<'a>(
+    matcher: &'a TermMatcher,
+    query: &str,
+    top_n: Option<usize>,
+) -> Vec<(&'a Term, f64)> {
     let mut results = matcher.rank_terms(query);
     if let Some(top_n) = top_n {
         let take_n = top_n.min(results.len());
         results = results[..take_n].to_vec();
     }
-    return results
+
+    results
 }

--- a/pyfuzon/Cargo.toml
+++ b/pyfuzon/Cargo.toml
@@ -15,6 +15,6 @@ fuzon = { version = "0.2.2", path = "../fuzon" }
 lazy_static = "1.5.0"
 oxrdf = "0.1.7"
 oxttl = "0.1.0-rc.1"
-pyo3 = { version = "0.22.2", features = ["abi3-py310"] }
+pyo3 = { version = "0.22.2", features = ["abi3-py310", "anyhow"] }
 ratatui = "0.28.1"
 rff = "0.3.0"

--- a/pyfuzon/python/pyfuzon/__init__.py
+++ b/pyfuzon/python/pyfuzon/__init__.py
@@ -5,3 +5,4 @@ if hasattr(pyfuzon, "__all__"):
     __all__ = pyfuzon.__all__
 
 from .matcher import TermMatcher
+from .cache import get_cache_key, get_cache_path

--- a/pyfuzon/python/pyfuzon/cache.py
+++ b/pyfuzon/python/pyfuzon/cache.py
@@ -16,8 +16,13 @@ For more information, see: https://github.com/dirs-dev/dirs-rs
 
 from pathlib import Path
 
-from .pyfuzon import get_cache_key as _get_cache_key
-from .pyfuzon import get_cache_path as _get_cache_path
+from .matcher import TermMatcher
+from .pyfuzon import (
+    get_cache_key as _get_cache_key,
+    get_cache_path as _get_cache_path,
+    cache_by_source as _cache_by_source,
+    load_by_source as _load_by_source,
+)
 
 def get_cache_key(sources: list[str]) -> str:
     """Return a deterministic cache key based on a collection of source paths."""
@@ -26,3 +31,12 @@ def get_cache_key(sources: list[str]) -> str:
 def get_cache_path(sources: list[str]) -> Path:
     """Return a full platform-specific cache path based on a collection of source paths."""
     return Path(_get_cache_path(sources))
+
+def cache_by_source(sources: list[str]):
+    """Save each source into an independent TermMatcher cache file."""
+    _cache_by_source(sources)
+
+def load_by_source(sources: list[str]) -> TermMatcher:
+    """Load and combine single-source cache entries into a combined TermMatcher."""
+    terms = _load_by_source(sources)
+    return TermMatcher(terms)

--- a/pyfuzon/python/pyfuzon/cache.py
+++ b/pyfuzon/python/pyfuzon/cache.py
@@ -1,0 +1,28 @@
+"""Caching utilities for pyfuzon.
+
+This module provides functions to help manage the cache of TermMatchers.
+Cache keys are built by fuzon using the sorted source paths. For each path,
+a stamp is computed as follows (missing values are replaced by empty strings):
+    + file path: {path}-{size}-{last-modified-datetime}
+    + url: {url}-{etag-checksum}-{last-modified-datetime}
+All stamps are then concatenated and hash of the result is used as the cache key.
+
+Cache paths adhere to the following specifications:
+    + Linux: XDG base / user directory
+    + Windows: Known folder API
+    + MacOS: Standard Directories guidelines
+For more information, see: https://github.com/dirs-dev/dirs-rs
+"""
+
+from pathlib import Path
+
+from .pyfuzon import get_cache_key as _get_cache_key
+from .pyfuzon import get_cache_path as _get_cache_path
+
+def get_cache_key(sources: list[str]) -> str:
+    """Return a deterministic cache key based on a collection of source paths."""
+    return _get_cache_key(sources)
+
+def get_cache_path(sources: list[str]) -> Path:
+    """Return a full platform-specific cache path based on a collection of source paths."""
+    return Path(_get_cache_path(sources))

--- a/pyfuzon/python/pyfuzon/matcher.py
+++ b/pyfuzon/python/pyfuzon/matcher.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 from typing import Self
+
 from dataclasses import dataclass
 
 from pyfuzon import Term, score_terms, parse_files, load_terms, dump_terms
@@ -10,7 +11,7 @@ class TermMatcher:
     """Fuzzy matches terms from RDF terminologies to input queries."""
 
     terms: list[Term]
-    
+
     def top(self, query: str, n: int=5) -> list[Term]:
         """Return the n terms most similar to input query."""
         return self.rank(query)[:n]
@@ -19,7 +20,7 @@ class TermMatcher:
         """Return all terms, ranked by query similarity."""
         scores = self.score(query)
         ranks = [
-            i[0] for i in 
+            i[0] for i in
             sorted(enumerate(scores), key=lambda x:x[1], reverse=True)
         ]
         return [self.terms[rank] for rank in ranks]
@@ -45,4 +46,3 @@ class TermMatcher:
     def dump(self, path):
         """Serialize to disk."""
         dump_terms(self.terms, path)
-

--- a/pyfuzon/src/lib.rs
+++ b/pyfuzon/src/lib.rs
@@ -110,6 +110,28 @@ pub fn get_cache_key(sources: Vec<String>) -> PyResult<String> {
     Ok(cache::get_cache_key(&mut src_ref)?)
 }
 
+/// Save each source in a dedicated TermMatcher cache file.
+#[pyfunction]
+pub fn cache_by_source(sources: Vec<String>) -> PyResult<()> {
+    let src_ref = sources.iter().map(|s| s.as_str()).collect();
+    cache::cache_by_source(src_ref)?;
+
+    Ok(())
+}
+
+/// Load terms from individual TermMatcher cache files for each source.
+#[pyfunction]
+pub fn load_by_source(sources: Vec<String>) -> PyResult<Vec<Term>> {
+    let src_ref = sources.iter().map(|s| s.as_str()).collect();
+    let terms = cache::load_by_source(src_ref)?
+        .terms
+        .into_iter()
+        .map(|t| Term::new(t.uri, t.label))
+        .collect();
+
+    Ok(terms)
+}
+
 #[pymodule]
 fn pyfuzon(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(score_terms, m)?)?;
@@ -118,6 +140,8 @@ fn pyfuzon(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(dump_terms, m)?)?;
     m.add_function(wrap_pyfunction!(get_cache_key, m)?)?;
     m.add_function(wrap_pyfunction!(get_cache_path, m)?)?;
+    m.add_function(wrap_pyfunction!(cache_by_source, m)?)?;
+    m.add_function(wrap_pyfunction!(load_by_source, m)?)?;
     m.add_class::<Term>()?;
 
     Ok(())

--- a/pyfuzon/src/lib.rs
+++ b/pyfuzon/src/lib.rs
@@ -50,7 +50,7 @@ pub fn score_terms(query: String, terms: Vec<Term>) -> PyResult<Vec<f64>> {
         })
         .collect();
 
-    return Ok(scores);
+    Ok(scores)
 }
 
 /// Parse and filter RDF files to gather the union of all terms.
@@ -61,7 +61,7 @@ pub fn parse_files(paths: Vec<String>) -> PyResult<Vec<Term>> {
         .map(|t| Term::new(t.uri, t.label))
         .collect();
 
-    return Ok(terms);
+    Ok(terms)
 }
 
 /// Extract terms from a serialized fuzon TermMatcher.
@@ -88,7 +88,7 @@ pub fn dump_terms(terms: Vec<Term>, path: PathBuf) -> PyResult<()> {
             label: t.label,
         })
         .collect();
-    matcher.dump(&path).unwrap();
+    matcher.dump(&path)?;
 
     Ok(())
 }
@@ -99,7 +99,7 @@ pub fn get_cache_path(sources: Vec<String>) -> PyResult<String> {
     let mut src_ref = sources.iter().map(|s| s.as_str()).collect();
     let cache_path = cache::get_cache_path(&mut src_ref)?;
 
-    return Ok(cache_path.to_str().unwrap().to_owned());
+    Ok(cache_path.to_str().unwrap().to_owned())
 }
 
 /// Get a deterministic cache key based on input collection of sources
@@ -107,7 +107,7 @@ pub fn get_cache_path(sources: Vec<String>) -> PyResult<String> {
 pub fn get_cache_key(sources: Vec<String>) -> PyResult<String> {
     let mut src_ref = sources.iter().map(|s| s.as_str()).collect();
 
-    return Ok(cache::get_cache_key(&mut src_ref)?);
+    Ok(cache::get_cache_key(&mut src_ref)?)
 }
 
 #[pymodule]
@@ -119,5 +119,6 @@ fn pyfuzon(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(get_cache_key, m)?)?;
     m.add_function(wrap_pyfunction!(get_cache_path, m)?)?;
     m.add_class::<Term>()?;
+
     Ok(())
 }

--- a/pyfuzon/src/lib.rs
+++ b/pyfuzon/src/lib.rs
@@ -74,7 +74,7 @@ pub fn load_terms(path: PathBuf) -> PyResult<Vec<Term>> {
         .map(|t| Term::new(t.uri, t.label))
         .collect();
 
-    return Ok(terms);
+    Ok(terms)
 }
 
 /// Serialize the provided terms as a fuzon TermMatcher.
@@ -90,7 +90,7 @@ pub fn dump_terms(terms: Vec<Term>, path: PathBuf) -> PyResult<()> {
         .collect();
     matcher.dump(&path).unwrap();
 
-    return Ok(());
+    Ok(())
 }
 
 /// Get a full platform-specific cache path based on input collection of sources.

--- a/pyfuzon/src/lib.rs
+++ b/pyfuzon/src/lib.rs
@@ -1,7 +1,6 @@
-use anyhow::Result;
 use core::fmt;
 use pyo3::prelude::*;
-use std::{io::BufRead, path::PathBuf};
+use std::path::PathBuf;
 
 use fuzon::{cache, gather_terms, get_source, TermMatcher};
 use rff;
@@ -97,8 +96,8 @@ pub fn dump_terms(terms: Vec<Term>, path: PathBuf) -> PyResult<()> {
 /// Get a full platform-specific cache path based on input collection of sources.
 #[pyfunction]
 pub fn get_cache_path(sources: Vec<String>) -> PyResult<String> {
-    let src_ref = sources.iter().map(|s| s.as_str()).collect();
-    let cache_path = cache::get_cache_path(&src_ref)?;
+    let mut src_ref = sources.iter().map(|s| s.as_str()).collect();
+    let cache_path = cache::get_cache_path(&mut src_ref)?;
 
     return Ok(cache_path.to_str().unwrap().to_owned());
 }
@@ -106,9 +105,9 @@ pub fn get_cache_path(sources: Vec<String>) -> PyResult<String> {
 /// Get a deterministic cache key based on input collection of sources
 #[pyfunction]
 pub fn get_cache_key(sources: Vec<String>) -> PyResult<String> {
-    let src_ref = sources.iter().map(|s| s.as_str()).collect();
+    let mut src_ref = sources.iter().map(|s| s.as_str()).collect();
 
-    return Ok(cache::get_cache_key(&src_ref)?);
+    return Ok(cache::get_cache_key(&mut src_ref)?);
 }
 
 #[pymodule]


### PR DESCRIPTION
Exposes caching helpers to the python API.

This also improves error handling throughout the library by returning Result instead of panicking.

## Context:

Many (not so) edge cases resulted in panics, because we use the [anyhow](https://docs.rs/anyhow/latest/anyhow/) crate to handle errors, and I did not know how to convert its `Result`s to `PyErr` in the python bindings. Turns out there's an [optional `anyhow` feature](https://pyo3.rs/main/doc/pyo3/anyhow/) in the PyO3 crate to auto-cast Results.


## Changes Summary:

* Propagate results throughout fuzon all the way to the python library.
* Expose caching helpers from rust to python.
* Improve documentation in the python library.