### PR TITLE
fix: exclude blank nodes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -876,7 +876,7 @@ dependencies = [
 
 [[package]]
 name = "fuzon"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "anyhow",
  "clap 4.5.18",
@@ -896,7 +896,7 @@ dependencies = [
 
 [[package]]
 name = "fuzon-http"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "actix-web",
  "clap 4.5.18",
@@ -1649,7 +1649,7 @@ dependencies = [
 
 [[package]]
 name = "pyfuzon"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "anyhow",
  "clap 4.5.18",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -883,7 +883,7 @@ dependencies = [
  "crossterm",
  "dirs",
  "lazy_static",
- "oxrdf 0.1.7",
+ "oxrdf",
  "oxrdfio",
  "oxttl",
  "postcard",
@@ -1483,17 +1483,6 @@ checksum = "85d9439ace287894b327bd5522d4f3d813311c719143a1af37826c6a12f808d0"
 
 [[package]]
 name = "oxrdf"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "309287c8a757e25e06a6156acbd73770bac3e319123f5b4bc0a42e232caf97a5"
-dependencies = [
- "oxilangtag",
- "oxiri",
- "rand",
-]
-
-[[package]]
-name = "oxrdf"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b2115dc40840037ba86c494ffa2925ab435ec0c383dcf73d49600c9142db081"
@@ -1510,7 +1499,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62b05ae7eeab84240bdf87bc8db8da4622a0ad202375e4de50ce32e97ea4061b"
 dependencies = [
- "oxrdf 0.2.1",
+ "oxrdf",
  "oxrdfxml",
  "oxttl",
  "thiserror",
@@ -1524,7 +1513,7 @@ checksum = "7f7b10f0ba68e0a300346264a97c33ad26d1e16700d481c4809caef26195a04a"
 dependencies = [
  "oxilangtag",
  "oxiri",
- "oxrdf 0.2.1",
+ "oxrdf",
  "quick-xml",
  "thiserror",
 ]
@@ -1538,7 +1527,7 @@ dependencies = [
  "memchr",
  "oxilangtag",
  "oxiri",
- "oxrdf 0.2.1",
+ "oxrdf",
  "thiserror",
 ]
 
@@ -1667,7 +1656,7 @@ dependencies = [
  "crossterm",
  "fuzon",
  "lazy_static",
- "oxrdf 0.1.7",
+ "oxrdf",
  "oxttl",
  "pyo3",
  "ratatui",

--- a/fuzon-http/Cargo.toml
+++ b/fuzon-http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuzon-http"
-version = "0.2.4"
+version = "0.2.5"
 license.workspace = true
 edition.workspace = true
 
@@ -8,7 +8,7 @@ edition.workspace = true
 actix-web = "4.9.0"
 clap = { version = "4.5.18", features = ["derive"] }
 env_logger = "0.11.5"
-fuzon = { version = "0.2.4", path = "../fuzon" }
+fuzon = { version = "0.2.5", path = "../fuzon" }
 log = "0.4.22"
 serde = { version = "1.0.210", features = ["derive"] }
 serde_json = "1.0.128"

--- a/fuzon/Cargo.toml
+++ b/fuzon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuzon"
-version = "0.2.4"
+version = "0.2.5"
 edition = "2021"
 
 [lib]

--- a/fuzon/Cargo.toml
+++ b/fuzon/Cargo.toml
@@ -12,7 +12,7 @@ clap = { version = "4.5.16", features = ["derive"] }
 crossterm = "0.28.1"
 dirs = "5.0.1"
 lazy_static = "1.5.0"
-oxrdf = "0.1.7"
+oxrdf = "0.2.1"
 oxrdfio = "0.1.0"
 oxttl = "0.1.0-rc.1"
 postcard = { version = "1.0.10", features = ["alloc"] }

--- a/pyfuzon/Cargo.toml
+++ b/pyfuzon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyfuzon"
-version = "0.2.4"
+version = "0.2.5"
 edition = "2021"
 
 [lib]
@@ -11,7 +11,7 @@ crate-type = ["cdylib"]
 anyhow = "1.0.86"
 clap = { version = "4.5.16", features = ["derive"] }
 crossterm = "0.28.1"
-fuzon = { version = "0.2.4", path = "../fuzon" }
+fuzon = { version = "0.2.5", path = "../fuzon" }
 lazy_static = "1.5.0"
 oxrdf = "0.2.1"
 oxttl = "0.1.0-rc.1"

--- a/pyfuzon/Cargo.toml
+++ b/pyfuzon/Cargo.toml
@@ -13,7 +13,7 @@ clap = { version = "4.5.16", features = ["derive"] }
 crossterm = "0.28.1"
 fuzon = { version = "0.2.4", path = "../fuzon" }
 lazy_static = "1.5.0"
-oxrdf = "0.1.7"
+oxrdf = "0.2.1"
 oxttl = "0.1.0-rc.1"
 pyo3 = { version = "0.22.2", features = ["abi3-py310", "anyhow"] }
 ratatui = "0.28.1"


### PR DESCRIPTION
fuzon is meant to find URIs based on fuzzy search of human-readable freetext.

Blank nodes do not have a deterministic URI and are therefore not useful for our purpose.

## Changes summary

* TermMatcher filters them out when loading terminologies.

## Additional changes

* All crates now use oxrdf 0.2.1